### PR TITLE
Make GitHub detect Forth files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.fi linguist-language=Forth
+*.f99 linguist-language=Forth
+v9t9/v9t9-c/tools/Forth/lib/* linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.fi`, `.f99`, and `Forth/lib` files as Forth.

Thanks!
